### PR TITLE
Use 3.9+ type hinting features

### DIFF
--- a/src/project_dilemma/config.py
+++ b/src/project_dilemma/config.py
@@ -2,7 +2,7 @@ import argparse
 import os.path
 import sys
 import tomllib
-from typing import Any, Dict, List, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import platformdirs
 
@@ -23,10 +23,10 @@ class NodeConfig(TypedDict):
 class ProjectDilemmaConfig(TypedDict):
     algorithms_directory: str
     generational_simulation: NotRequired[DynamicImport]
-    nodes: List[NodeConfig]
+    nodes: list[NodeConfig]
     simulation: DynamicImport
     simulation_id: str
-    simulation_arguments: Dict[str, Any]
+    simulation_arguments: dict[str, Any]
     simulation_data: NotRequired[str]
     simulation_data_output: NotRequired[str]
     simulation_results_output: NotRequired[str]

--- a/src/project_dilemma/interfaces/algorithm.py
+++ b/src/project_dilemma/interfaces/algorithm.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import Optional, Self
+from typing import Self
 
 import project_dilemma.interfaces.base as pd_int_base
 
@@ -37,9 +37,9 @@ class Algorithm(pd_int_base.Base):
     ]
 
     algorithm_id: str
-    mutations: Optional[Sequence[type[Self]]] = None
+    mutations: Sequence[type[Self]] | None = None
 
-    def __init__(self, mutations: Optional[Sequence[type[Self]]] = None, **kwargs) -> None:
+    def __init__(self, mutations: Sequence[type[Self]] | None = None, **kwargs) -> None:
         self.mutations = mutations
 
     def __eq__(self, other: Self):

--- a/src/project_dilemma/interfaces/generational_simulation.py
+++ b/src/project_dilemma/interfaces/generational_simulation.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from collections.abc import MutableMapping, Sequence
 from copy import deepcopy
 import sys
-from typing import Any, Optional
+from typing import Any
 
 import project_dilemma.interfaces.base as pd_int_base
 import project_dilemma.interfaces.node as pd_int_node
@@ -36,7 +36,7 @@ class GenerationalSimulation(pd_int_simulation.SimulationBase):
                  nodes: Sequence[pd_int_node.Node],
                  generations: int,
                  generational_simulation: type[pd_int_simulation.SimulationBase],
-                 simulation_data: Optional[pd_int_base.Simulations] = None,
+                 simulation_data: pd_int_base.Simulations | None = None,
                  **kwargs):
         super().__init__(nodes=nodes, simulation_id=simulation_id, simulation_data=simulation_data)
         self.generations = generations

--- a/src/project_dilemma/interfaces/simulation.py
+++ b/src/project_dilemma/interfaces/simulation.py
@@ -16,7 +16,6 @@ limitations under the License.
 from abc import abstractmethod
 from collections import Counter
 from collections.abc import Sequence
-from typing import Optional
 
 import project_dilemma.interfaces.base as pd_int_base
 import project_dilemma.interfaces.node as pd_int_node
@@ -74,7 +73,7 @@ class SimulationBase(pd_int_base.Base):
         return self._simulation_data
 
     @simulation_data.setter
-    def simulation_data(self, simulation_data: Optional[pd_int_base.Generations | pd_int_base.Simulations]):
+    def simulation_data(self, simulation_data: pd_int_base.Generations | pd_int_base.Simulations | None):
         if not simulation_data:
             self._simulation_data = {}
         else:

--- a/src/project_dilemma/object_loaders.py
+++ b/src/project_dilemma/object_loaders.py
@@ -2,14 +2,13 @@ import importlib
 import json
 import os.path
 import sys
-from typing import Dict, List
 
 from project_dilemma.config import ProjectDilemmaConfig
 from project_dilemma.interfaces import Algorithm, Generations, Node, SimulationBase, Simulations
 from project_dilemma.simulations import simulations_map
 
 
-def create_nodes(config: ProjectDilemmaConfig, algorithms_map: Dict[str, type[Algorithm]]) -> List[type[Node]]:
+def create_nodes(config: ProjectDilemmaConfig, algorithms_map: dict[str, type[Algorithm]]) -> list[type[Node]]:
     """create the simulation nodes
 
     :param config: configuration data
@@ -32,7 +31,7 @@ def create_nodes(config: ProjectDilemmaConfig, algorithms_map: Dict[str, type[Al
     return nodes
 
 
-def load_algorithms(config: ProjectDilemmaConfig) -> Dict[str, type[Algorithm]]:
+def load_algorithms(config: ProjectDilemmaConfig) -> dict[str, type[Algorithm]]:
     """load all algorithms used
 
     :param config: configuration data
@@ -43,7 +42,7 @@ def load_algorithms(config: ProjectDilemmaConfig) -> Dict[str, type[Algorithm]]:
     sys.path.append(config['algorithms_directory'])
 
     algorithms = [node['algorithm'] for node in config['nodes']]
-    algorithm_map: Dict[str, type[Algorithm]] = {}
+    algorithm_map: dict[str, type[Algorithm]] = {}
 
     for algorithm in algorithms:
         if algorithm_map.get(algorithm['object']):


### PR DESCRIPTION
Since this package is only for 3.11 and above, you might as well want to use modern type hinting features. There are also some type bugs, but I reckon that's for another issue.